### PR TITLE
initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,36 @@
+{
+  "name": "iron-checked-element-behavior",
+  "version": "1.0.0",
+  "description": "Implements an element that has a checked attribute and can be added to a form",
+  "authors": "The Polymer Authors",
+  "keywords": [
+    "web-components",
+    "polymer",
+    "iron",
+    "behavior"
+  ],
+  "main": [
+    "iron-checked-element-behavior.html"
+  ],
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PolymerElements/iron-checked-element-behavior.git"
+  },
+  "license": "http://polymer.github.io/LICENSE.txt",
+  "homepage": "https://github.com/PolymerElements/iron-checked-element-behavior",
+  "ignore": [],
+  "dependencies": {
+    "polymer": "Polymer/polymer#^1.0.0",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0"
+  },
+  "devDependencies": {
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "web-component-tester": "*",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <title>iron-checked-element-behavior demo</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="simple-checkbox.html">
+</head>
+<body unresolved>
+  <div class="horizontal-section-container">
+    <div>
+      <h4>Not required</h4>
+      <div class="horizontal-section">
+        <simple-checkbox></simple-checkbox>
+      </div>
+    </div>
+    <div>
+      <h4>Required</h4>
+      <div class="horizontal-section">
+        <simple-checkbox required></simple-checkbox>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/demo/simple-checkbox.html
+++ b/demo/simple-checkbox.html
@@ -1,0 +1,64 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../paper-button/paper-button.html">
+<link rel="import" href="../iron-checked-element-behavior.html">
+
+<dom-module id="simple-checkbox">
+  <style>
+    :host {
+      display: block;
+    }
+
+    :host([invalid]) span {
+      color: red;
+    }
+
+    #labelText {
+      display: inline-block;
+      width: 100px;
+    }
+  </style>
+  <template>
+    <input type="checkbox" id="checkbox" on-tap="_onCheckTap">
+    <span id="labelText">{{label}}</span>
+    <paper-button raised on-click="_onClick">validate</paper-button>
+
+  </template>
+  <script>
+    Polymer({
+
+      is: 'simple-checkbox',
+
+      behaviors: [
+        Polymer.IronCheckedElementBehavior
+      ],
+
+      properties: {
+        label: {
+          type: String,
+          value: 'not validated'
+        }
+      },
+
+      _onCheckTap: function() {
+        this.checked = this.$.checkbox.checked;
+      },
+
+      _onClick: function() {
+        this.validate();
+        this.label = this.invalid ? 'is invalid' : 'is valid';
+      }
+    });
+
+  </script>
+
+  </dom-module>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+  <title>iron-checked-element-behavior</title>
+
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../polymer/polymer.html">
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+  <iron-component-page></iron-component-page>
+
+</body>
+</html>

--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -1,0 +1,82 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
+
+<script>
+
+  /**
+   * Use `Polymer.IronCheckedElementBehavior` to implement a custom element
+   * that has a `checked` property, which can be used for validation if the
+   * element is also `required`. Element instances implementing this behavior
+   * will also be registered for use in an `iron-form` element.
+   *
+   * @demo demo/index.html
+   * @polymerBehavior Polymer.IronCheckedElementBehavior
+   */
+  Polymer.IronCheckedElementBehaviorImpl = {
+
+    properties: {
+
+      /**
+       * Gets or sets the state, `true` is checked and `false` is unchecked.
+       */
+      checked: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+        notify: true,
+      },
+
+      /**
+       * If true, the button toggles the active state with each tap or press
+       * of the spacebar.
+       */
+      toggles: {
+        type: Boolean,
+        value: true,
+        reflectToAttribute: true
+      }
+    },
+
+    observers: [
+      '_requiredChanged(required)'
+    ],
+
+    /**
+     * Returns false if the element is required and not checked, and true otherwise.
+     * @return {Boolean} true if `required` is false, or if `required` and `checked` are both true.
+     */
+    _getValidity: function() {
+      return this.disabled || !this.required || (this.required && this.checked);
+    },
+
+    /**
+     * Update the aria-required label when `required` is changed.
+     */
+    _requiredChanged: function() {
+      if (this.required) {
+        this.setAttribute('aria-required', 'true');
+      } else {
+        this.removeAttribute('aria-required');
+      }
+    },
+  };
+
+  /** @polymerBehavior Polymer.IronCheckedElementBehavior */
+  Polymer.IronCheckedElementBehavior = [
+    Polymer.IronFormElementBehavior,
+    Polymer.IronValidatableBehavior,
+    Polymer.IronCheckedElementBehaviorImpl
+  ];
+
+</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-checked-element-behavior basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link href="../../test-fixture/test-fixture.html" rel="import">
+  <link href="../../iron-meta/iron-meta.html" rel="import">
+  <link href="simple-checkbox.html" rel="import">
+
+</head>
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <simple-checkbox></simple-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="checked">
+    <template>
+      <simple-checkbox checked></simple-checkbox>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('basic', function() {
+      test('can be checked', function() {
+        var c = fixture('basic');
+        assert.isFalse(c.checked);
+        c.checked = true;
+        assert.isTrue(c.checked);
+      });
+
+      test('can be unchecked', function() {
+        var c = fixture('checked');
+        assert.isTrue(c.checked);
+        c.checked = false;
+        assert.isFalse(c.checked);
+      });
+
+      test('invalid if required and not checked', function() {
+        var c = fixture('basic');
+        c.required = true;
+        assert.isFalse(c.checked);
+        assert.isFalse(c.validate());
+        assert.isTrue(c.invalid);
+      });
+
+      test('valid if required and checked', function() {
+        var c = fixture('basic');
+        c.required = true;
+        c.checked = true;
+        assert.isTrue(c.checked);
+        assert.isTrue(c.validate());
+        assert.isFalse(c.invalid);
+      });
+
+      test('valid if not required and not checked', function() {
+        var c = fixture('basic');
+        assert.isFalse(c.checked);
+        assert.isTrue(c.validate());
+        assert.isFalse(c.invalid);
+      });
+
+      test('setting `required` sets `aria-required=true`', function() {
+        var c = fixture('basic');
+        c.required = true;
+        assert.equal(c.getAttribute('aria-required'), 'true');
+        c.required = false;
+        assert.isFalse(c.hasAttribute('aria-required'));
+      });
+
+      test('setting `invalid` sets `aria-invalid=true`', function() {
+        var c = fixture('basic');
+        c.invalid = true;
+        assert.equal(c.getAttribute('aria-invalid'), 'true');
+        c.invalid = false;
+        assert.isFalse(c.hasAttribute('aria-invalid'));
+      });
+
+    });
+
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <title>iron-checked-element-behavior tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../web-component-tester/browser.js"></script>
+
+  </head>
+  <body>
+
+    <script>
+
+      WCT.loadSuites([
+        'basic.html'
+      ]);
+
+    </script>
+
+  </body>
+</html>

--- a/test/simple-checkbox.html
+++ b/test/simple-checkbox.html
@@ -1,0 +1,26 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-checked-element-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'simple-checkbox',
+
+    behaviors: [
+      Polymer.IronCheckedElementBehavior
+    ]
+
+  });
+
+</script>


### PR DESCRIPTION
This behaviour pulls out the common `checked`-related things between `paper-checkbox`/`paper-radio-button`/`paper-toggle-button` (last bit of https://github.com/PolymerElements/paper-behaviors/issues/22). The idea is that it should:
- add the `checked` property
- handle the `required` and `validate` methods needed _if_ it were to be added to a form. 

Depends on (review top to bottom):
- [x] ~~https://github.com/PolymerElements/iron-validatable-behavior/pull/12~~
- [x] ~~https://github.com/PolymerElements/iron-form-element-behavior/pull/16~~
- [x] ~~https://github.com/PolymerElements/iron-form/pull/37~~

This would make `paper-checkbox` look something like this: https://github.com/PolymerElements/paper-checkbox/pull/40/files

/cc @morethanreal for extra halp
