### PR TITLE
checked elements have default values

### DIFF
--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -26,6 +26,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.IronCheckedElementBehaviorImpl = {
 
     properties: {
+      /**
+       * Fired when the checked state changes.
+       *
+       * @event iron-change
+       */
 
       /**
        * Gets or sets the state, `true` is checked and `false` is unchecked.
@@ -35,6 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: false,
         reflectToAttribute: true,
         notify: true,
+        observer: '_checkedChanged'
       },
 
       /**
@@ -45,6 +51,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Boolean,
         value: true,
         reflectToAttribute: true
+      },
+
+      /* Overriden from Polymer.IronFormElementBehavior */
+      value: {
+        type: String,
+        value: ''
       }
     },
 
@@ -70,6 +82,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.removeAttribute('aria-required');
       }
     },
+
+    /**
+     * Update the element's value when checked.
+     */
+    _checkedChanged: function() {
+      this.active = this.checked;
+      // Unless the user has specified a value, a checked element has the
+      // default value "on" when checked.
+      if (this.value === '')
+        this.value = this.checked ? 'on' : '';
+      this.fire('iron-change');
+    }
   };
 
   /** @polymerBehavior Polymer.IronCheckedElementBehavior */

--- a/test/basic.html
+++ b/test/basic.html
@@ -37,6 +37,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="with-value">
+    <template>
+      <simple-checkbox value="batman"></simple-checkbox>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
@@ -78,6 +84,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(c.invalid);
       });
 
+      test('has a default value of "on" when checked', function() {
+        var c = fixture('basic');
+        assert.isTrue(c.value === '');
+
+        c.checked = true;
+        assert.isTrue(c.value === 'on');
+      });
+
+      test('does not stomp over user defined value when checked', function() {
+        var c = fixture('with-value');
+        assert.isTrue(c.value === 'batman');
+
+        c.checked = true;
+        assert.isTrue(c.value === 'batman');
+      });
+    });
+
+    suite('a11y', function() {
       test('setting `required` sets `aria-required=true`', function() {
         var c = fixture('basic');
         c.required = true;
@@ -93,7 +117,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         c.invalid = false;
         assert.isFalse(c.hasAttribute('aria-invalid'));
       });
-
     });
 
   </script>


### PR DESCRIPTION
Both native checkboxes and radio buttons have a value of "on" (unless a `value` is provided explicitly by the user).

Also added the `_checkedChanged` method, since that will also be common to radio buttons/checkboxes/toggles.
