### PR TITLE
Fix a few typechecking nits for the compiler

### DIFF
--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -66,9 +66,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Returns false if the element is required and not checked, and true otherwise.
-     * @return {Boolean} true if `required` is false, or if `required` and `checked` are both true.
+     * @return {boolean} true if `required` is false, or if `required` and `checked` are both true.
      */
-    _getValidity: function() {
+    _getValidity: function(_value) {
       return this.disabled || !this.required || (this.required && this.checked);
     },
 


### PR DESCRIPTION
`_getValidity` is defined in `IronValidatableBehavior` as taking an argument, and also called as such, so that upsets the compiler.

Also `boolean` is preferred over `Boolean`, which closure compiler reserves for the Object values returned from `new Boolean(...)`
