### PR TITLE
Adds duck-typing flag; sets value to 'on' whenever it gets set to undefined / null.

### DIFF
--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -66,6 +66,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     created: function() {
+      // Used by `iron-form` to handle the case that an element with this behavior
+      // doesn't have a role of 'checkbox' or 'radio', but should still only be
+      // included when the form is serialized if `this.checked === true`.
       this._hasIronCheckedElementBehavior = true;
     },
 
@@ -88,11 +91,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    /**
+     * Fire `iron-changed` when the checked state changes.
+     */
     _checkedChanged: function() {
       this.active = this.checked;
       this.fire('iron-change');
     },
 
+    /**
+     * Reset value to 'on' if it is set to `undefined`.
+     */
     _valueChanged: function() {
       if (this.value === undefined || this.value === null) {
         this.value = 'on';

--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -56,7 +56,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /* Overriden from Polymer.IronFormElementBehavior */
       value: {
         type: String,
-        value: ''
+        value: 'on',
+        observer: '_valueChanged'
       }
     },
 
@@ -89,6 +90,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _checkedChanged: function() {
       this.active = this.checked;
       this.fire('iron-change');
+    },
+
+    _valueChanged: function() {
+      if (this.value === undefined) this.value = 'on';
     },
 
     valueForFormSerialization: function() {

--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -88,11 +88,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _checkedChanged: function() {
       this.active = this.checked;
+      this.fire('iron-change');
+    },
+
+    valueForFormSerialization: function() {
       // Unless the user has specified a value, a checked element has the
       // default value "on" when checked.
-      if (this.value === '')
-        this.value = this.checked ? 'on' : '';
-      this.fire('iron-change');
+      return this.checked ? (this.value || 'on') : '';
     }
   };
 

--- a/iron-checked-element-behavior.html
+++ b/iron-checked-element-behavior.html
@@ -65,6 +65,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       '_requiredChanged(required)'
     ],
 
+    created: function() {
+      this._hasIronCheckedElementBehavior = true;
+    },
+
     /**
      * Returns false if the element is required and not checked, and true otherwise.
      * @return {boolean} true if `required` is false, or if `required` and `checked` are both true.
@@ -84,22 +88,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    /**
-     * Update the element's value when checked.
-     */
     _checkedChanged: function() {
       this.active = this.checked;
       this.fire('iron-change');
     },
 
     _valueChanged: function() {
-      if (this.value === undefined) this.value = 'on';
-    },
-
-    valueForFormSerialization: function() {
-      // Unless the user has specified a value, a checked element has the
-      // default value "on" when checked.
-      return this.checked ? (this.value || 'on') : '';
+      if (this.value === undefined || this.value === null) {
+        this.value = 'on';
+      }
     }
   };
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -84,9 +84,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(c.invalid);
       });
 
-      test('has a default value of "on" when checked', function() {
+      test('has a default value of "on", always', function() {
         var c = fixture('basic');
-        assert.isTrue(c.value === '');
+
+        assert.isTrue(c.value === 'on');
 
         c.checked = true;
         assert.isTrue(c.value === 'on');
@@ -98,6 +99,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         c.checked = true;
         assert.isTrue(c.value === 'batman');
+      });
+
+      test('value returns "on" when no explicit value is specified', function() {
+        var c = fixture('basic');
+
+        assert.equal(c.value, 'on', 'returns "on"');
+      });
+
+      test('value returns the value when an explicit value is set', function() {
+        var c = fixture('basic');
+
+        c.value = 'abc';
+        assert.equal(c.value, 'abc', 'returns "abc"');
+
+        c.value = '123';
+        assert.equal(c.value, '123', 'returns "123"');
+      });
+
+      test('value returns "on" when value is set to undefined', function() {
+        var c = fixture('basic');
+
+        c.value = 'abc';
+        assert.equal(c.value, 'abc', 'returns "abc"');
+
+        c.value = undefined;
+        assert.equal(c.value, 'on', 'returns "on"');
       });
     });
 


### PR DESCRIPTION
Part of a fix for PolymerElements/paper-toggle-button#66.
Depends on PolymerElements/iron-form#82.
